### PR TITLE
enable frank copula

### DIFF
--- a/R/gamBiCopSelect.R
+++ b/R/gamBiCopSelect.R
@@ -139,7 +139,7 @@ gamBiCopSelect <- function(udata, lin.covs = NULL, smooth.covs = NULL,
   }
 
   if (length(familyset) == 1 && is.na(familyset)) {
-    familyset <- get.familyset()
+    familyset <- setdiff(get.familyset(), 5)
   }
   if (rotations) {
     familyset <- withRotations(familyset)

--- a/R/utilsFamilies.R
+++ b/R/utilsFamilies.R
@@ -1,7 +1,7 @@
 ## The current familyset of the gamCopula package
 get.familyset <- function() {
   # the Frank is available, but it works poorly.... still don't know why
-  c(1, 2, 301:304, 401:404)
+  c(1, 2, 5, 301:304, 401:404)
 }
 
 ## Fisher information with respect to the Copula parameter for a

--- a/R/utilsPrivate.R
+++ b/R/utilsPrivate.R
@@ -54,7 +54,7 @@ prepare.data <- function(data, covariates, trunclevel = NA,
     familyset <- 0
   }
   if (length(familyset) == 1 && is.na(familyset)) {
-    familyset <- get.familyset()
+    familyset <- setdiff(get.familyset(), 5)
   }
   if (rotations) {
     familyset <- withRotations(familyset)
@@ -107,7 +107,7 @@ prepare.data2 <- function(udata, lin.covs, smooth.covs, trunclevel = NA,
     familyset <- 0
   }
   if (length(familyset) == 1 && is.na(familyset)) {
-    familyset <- get.familyset()
+    familyset <- setdiff(get.familyset(), 5)
   }
   if (rotations) {
     familyset <- withRotations(familyset)


### PR DESCRIPTION
See #17.  For the Frank we can't use Fisher-Scoring and NR is slower. Other than that, there is this comment though:

https://github.com/tvatter/gamCopula/blob/585fa1ac78aa986cf6ad9bf379e56e69d32672ac/R/utilsFamilies.R#L2-L5

So I'm not sure, whether it is disabled on purpose. This PR allows to use the Frank, but does not include it in the default familyset.